### PR TITLE
Use Poisson distribution instead of `Math.random()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6157,6 +6157,11 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "random-bytes-numbers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes-numbers/-/random-bytes-numbers-1.0.0.tgz",
+      "integrity": "sha512-3WxI/wFi4OzV0HnUOxcT/JBKRiZURsJLQwmUqpmUMr0U7qyexCHf7sh6PxJBB0BXjmcSP9udQGHeiAkdGyMA8Q=="
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "@subspace/network": "github:subspace/network",
     "@subspace/storage": "github:subspace/storage",
     "@subspace/tracker": "github:subspace/tracker",
-    "@subspace/wallet": "github:subspace/wallet"
+    "@subspace/wallet": "github:subspace/wallet",
+    "random-bytes-numbers": "^1.0.0"
   },
   "devDependencies": {
     "@types/jest": "^23.3.10",

--- a/src/subspace.ts
+++ b/src/subspace.ts
@@ -29,6 +29,7 @@ import {
 } from './interfaces'
 import {Message} from "./Message";
 import {ArrayMap} from "array-map-set";
+import {random} from 'random-bytes-numbers';
 
 const DEFAULT_PROFILE_NAME = 'name'
 const DEFAULT_PROFILE_EMAIL = 'name@name.com'
@@ -98,6 +99,13 @@ const MESSAGE_TYPES = {
 
   'peer-added': 33,
   'peer-removed': 33,
+}
+
+/**
+ * Generates exponentially distributed numbers that can be used for intervals between arrivals in Poisson process
+ */
+function sample(mean: number): number {
+  return -Math.log(random()) * mean
 }
 
 export default class Subspace extends EventEmitter {
@@ -364,7 +372,7 @@ export default class Subspace extends EventEmitter {
             // a valid neighbor has failed
             console.log('A valid neighbor has failed')
             this.failedNeighbors.set(nodeIdString, false)
-            const timeout = Math.random() * 10
+            const timeout = sample(10)
             console.log('Failure timeout is', timeout)
             setTimeout(async () => {
               // later attempt to ping the node

--- a/types/random-bytes-numbers/index.d.ts
+++ b/types/random-bytes-numbers/index.d.ts
@@ -1,0 +1,6 @@
+/**
+ * This only covers minimal surface touched by this project, not entire library
+ */
+declare module 'random-bytes-numbers' {
+  export function random(): number;
+}


### PR DESCRIPTION
As we've talked before, this simple change replaces cryptographically insecure `Math.random()` with Poisson distribution