### PR TITLE
Dockerfile and instructions for building amd64 image (default Docker architecture)

### DIFF
--- a/Dockerfile-arm32v7
+++ b/Dockerfile-arm32v7
@@ -1,4 +1,4 @@
-FROM node:10
+FROM arm32v7/node:10
 
 WORKDIR /code
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ yarn
 node fullNode.js
 ```
 
-### Building Docker image for Raspberry PI
+### Building Docker image
 In order to get source code and build an image run:
 ```bash
 git clone git@github.com:subspace/subspace.git
@@ -20,4 +20,17 @@ docker build -t subspacelabs/subspace .
 If you want to push new image to Subspace's Docker Hub organization afterwards:
 ```bash
 docker push subspacelabs/subspace
+```
+
+### Building Docker image for Raspberry PI (32-bit ARMv7)
+In order to get source code and build an image run:
+```bash
+git clone git@github.com:subspace/subspace.git
+cd subspace
+docker build -t subspacelabs/subspace:arm32v7 -f Dockerfile-arm32v7 .
+```
+
+If you want to push new image to Subspace's Docker Hub organization afterwards:
+```bash
+docker push subspacelabs/subspace:arm32v7
 ```


### PR DESCRIPTION
While we only use Docker image for RPI right now, making it default image was not the best decision.
Let's make default image amd64, since this is default architecture for Docker and use `arm32v7` tag for RPI image (we might add `aarch64` soon if it seems necessary and brings better performance to the protocol).